### PR TITLE
Refresh tutorial deps for 2026: Flask 3.1, pytest 9, orb v4, Python 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 orbs:
-  python: circleci/python@2.1.1
+  python: circleci/python@4.0.0
 jobs:
   build-and-test:
     docker:
-      - image: cimg/python:3.11.3
+      - image: cimg/python:3.13
     steps:
       - checkout
       - python/install-packages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Flask==2.2.3
-pytest==7.3.1
-Werkzeug==2.2.2
+Flask==3.1.3
+pytest==9.0.2


### PR DESCRIPTION
## Summary

Refreshes the sample repo to match a 2026-current audit of the *Testing a Flask framework with pytest* blog tutorial. Three things change: dependencies move to current stable versions, the Werkzeug workaround pin is removed, and the CircleCI config moves to the latest orb plus a current Python image. The article (`Testing a Flask framework with pytest.md`) gets a matching update in a separate content-repo PR — its changelog is included below so reviewers can see the article and the repo align.

The original tutorial ran clean before this PR (Flask 2.2.3, pytest 7.3.1, orb 2.1.1, `cimg/python:3.11.3`). This PR is a freshness pass, not a bug fix, with one exception: the article had a copy typo ("Havard" vs the repo's "Harvard") that broke any reader pasting the article's test verbatim — fixed in the article PR.

## Changes in this PR

- `requirements.txt`:
  - `Flask==2.2.3` → `Flask==3.1.3`
  - `pytest==7.3.1` → `pytest==9.0.2`
  - `Werkzeug==2.2.2` removed (only existed as a workaround for the Flask 2.2.x / Werkzeug 3.0 incompat — Flask 3.1 declares its own `Werkzeug>=3.1`).
- `.circleci/config.yml`:
  - `circleci/python@2.1.1` (Sept 2022) → `circleci/python@4.0.0` (Jan 2026).
  - `cimg/python:3.11.3` → `cimg/python:3.13`.

The `python/install-packages` step interface is unchanged across orb 2.1.1 → 4.0.0, so no other config edits are needed.

## Validation

Ran end-to-end in a fresh `cimg/python:3.13` container, no cached state:

- `pip install -r requirements.txt` succeeds, resolving Flask 3.1.3, pytest 9.0.2, Werkzeug 3.1.8.
- `pytest` — 2 passed in 0.05s.
- `pytest -m get_request` — 1 passed, 1 deselected.
- `pytest -s` — passes; the marker filter and stdout capture both work as the article describes.
- `circleci config validate .circleci/config.yml` — "Config file at .circleci/config.yml is valid."

## Companion article changes (separate PR)

For reviewer context, the matching article PR (filed against the blog content repo) makes these edits:

- Update the prerequisite from "Python >= 3.5" to "Python >= 3.11".
- Fix the "Havard" → "Harvard" typo in the `books` data block, in `test_get_all_books`, and in the prose sentence that names the first book's author.
- Update the inline `config.yml` snippet to `circleci/python@4.0.0` and `cimg/python:3.13` to match this PR.
- Replace the awkward "orbs condense multiple lines of code into a single line" sentence with an accurate one-liner about orbs being reusable config packages.
- Correct the side note that incorrectly attributes the `bytes` response to pytest — it's Flask's `test_client` / `response.data` that returns bytes.
- Note that `pip install -r requirements.txt` already installs pytest, so the standalone `pip install pytest` step is redundant for readers who followed the prerequisites.
- Refresh two Flask docs links from `/en/2.0.x/` to `/en/stable/`.

## Out of scope / open question for maintainer

`api.py` line 38, `get_by_id`, returns `books[0]` instead of `book[0]`. That means any request to `/bookapi/books/<id>` returns the first book regardless of `id`. The article's `test_get_book_by_id` only requests id=1 so the test passes by coincidence. Fixing it would be a one-line change but it's a behavior change in tutorial example code, so I left it for a separate decision rather than smuggling it into this dependency-refresh PR. Happy to add a commit if you want it in here.

## Manual steps to reproduce

- Clone the repo, `git checkout update/tutorial-2026-refresh`.
- `pip install -r requirements.txt`
- `pytest` should report 2 passed.
- No API keys, no paid services, no host system state needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)